### PR TITLE
chore: add workflow to lint pull requests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,38 @@
+name: Linting Scripts
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [20.x]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install PHP dependencies with Composer
+        uses: php-actions/composer@v6
+        with:
+          php_version: '7.4'
+          version: 2.x
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+        env:
+          CI: true
+


### PR DESCRIPTION
Adds a workflow to run linting on pull requests against `main`.

## Validation
1. View the workflow run that was triggered by this PR: https://github.com/sparkbox/sparkpress-wordpress-starter/actions/runs/6089213573/job/16521529691
1. Verify that the output contains linting information and that the linting step passed