### PR TITLE
chore: workflow to upload theme directory artifact

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,7 +15,6 @@ node_modules
 package-lock.json
 package.json
 php.ini
-plugins
 src
 tasks
 test

--- a/.github/workflows/deploy.docker.yml
+++ b/.github/workflows/deploy.docker.yml
@@ -1,0 +1,54 @@
+name: Build Docker Image
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    if: ${{ vars.DEPLOY_WITH_DOCKER }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Install custom plugin npm dependencies
+        run: npm run plugins:install
+
+      - name: Install PHP dependencies with Composer
+        uses: php-actions/composer@v6
+        with:
+          php_version: '8.1'
+          version: 2.x
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build theme
+        run: npm run build:prod
+
+      - name: 'Login to GitHub Container Registry'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GH_TOKEN}}
+
+      - name: 'Build Inventory Image'
+        run: |
+          docker build . --tag ghcr.io/sparkbox/sparkpress:latest
+          docker push ghcr.io/sparkbox/sparkpress:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM php:8.1-apache-buster
+FROM php:8.1-apache-buster as dev
+
+LABEL org.opencontainers.image.source=https://github.com/sparkbox/sparkpress-wordpress-starter
 
 # When changings, also change in .circleci/config.yml
 ENV WP_VERSION=6.3.1
@@ -36,3 +38,11 @@ RUN find /var/www/ -type f -exec chmod 644 {} \;
 # make the linters executable so we can run them from containers
 RUN chmod +x vendor/bin/phpcs
 RUN chmod +x vendor/bin/twigcs
+
+FROM dev as prod
+
+COPY theme /var/www/html/wp-content/themes/sparkpress-theme
+COPY plugins /var/www/html/wp-content/plugins
+COPY wp-configs/wp-config.php /var/www/html/wp-config.php
+COPY wp-configs/php.ini /var/www/html/php.ini
+COPY wp-configs/.htaccess /var/www/html/.htaccess

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,9 @@ version: '3.7'
 
 services:
   web:
-    build: .
+    build:
+      context: .
+      target: dev
     container_name: sparkpress
     ports:
       - '8000:80'


### PR DESCRIPTION
## Description
This adds a GitHub Actions workflow that builds a Docker image using the repo's existing Dockerfile

Closes #21 

## To Validate
- [ ] Check the [most recent run of the workflow](https://github.com/sparkbox/sparkpress-wordpress-starter/actions/runs/6278211428/job/17051547424) (before run on PR was disabled) and confirm that it was successful and that it is the product of the [most recent SparkPress package](https://github.com/sparkbox/sparkpress-wordpress-starter/pkgs/container/sparkpress) (the `sha256` on the package tagged `latest` should match the one at the bottom of the "Build Inventory Image" step of the workflow). Optionally, you can also push a commit to run the workflow on PR and check it from there.
- [ ] The created package should be associated with the repository, you should see it if you click on "Code" from the repo, it should also be visible under "Packages" from github.com/sparkbox and shows that it belongs in sparkbox/sparkpress-wordpress-starter.

**Note:** You should also be able to pull/run the image but it's kind of a hassle! You'd need to [authenticate to the container registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic). To run it locally I modified the `docker-compose.yml` as seen below and ran `docker-compose up`.

```
web:
    # build: .
    image: ghcr.io/sparkbox/sparkpress:latest
```