### PR TITLE
chore: default theme to sparkpress-theme

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -22,6 +22,9 @@ require __DIR__ . '/vendor/autoload.php';
 $dotenv = Dotenv\Dotenv::createImmutable( __DIR__ );
 $dotenv->load();
 
+/** Set default theme to SparkPress  */
+define('WP_DEFAULT_THEME', 'sparkpress-theme');
+
 // ** MySQL settings - You can get this info from your web host ** //
 /** The name of the database for WordPress */
 define( 'DB_NAME', getenv( 'MYSQL_DATABASE' ) );


### PR DESCRIPTION
## Description

Prevents the need to manually switch the theme in the wp-admin in order to prevent the error `The theme directory "twentytwentythree" does not exist.` when loading the page.

Closes #25 

## To Validate
- [ ] Pull down this branch locally.
- [ ] Stop the running Docker container.
- [ ] Run `docker rm sparkpress sparkpress_db` and `docker volume rm sparkpress-wordpress-starter_db_data` to remove the docker containers and volume associated with this project, or delete them from Docker Desktop.
- [ ] Run `npm start` to recreate/start the containers.
- [ ] Navigate to http://localhost:8000/ and follow installation instructions.
- [ ] Ensure that only one theme appears when going to Appearance > Themes in WP under http://localhost:8000/wp_admin
- [ ] When navigating to http://localhost:8000, ensure that there is no more error/warning on the page that says `The theme directory "twentytwentythree" does not exist.`