### PR TITLE
chore: set up release please action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,19 @@
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+name: release-please
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: node
+          package-name: sparkpress


### PR DESCRIPTION
## Description

This adds a workflow to run [Release Please](https://github.com/googleapis/release-please) on merges to `main` to create release PRs. The super simple configuration _should_ work for our use case, analyzing conventional commits to determine a new version number, updating a changelog, and tagging releases (tagging may only happen when the release PR is merged, though).

Closes #23
Closes #38 

## To Validate

1. View the test PR, #47, confirming that it makes sensible changes given the codebase (the changelog ignores chore, style, and refactor commits, which is why there's so little in there)
2. View the output from the [GitHub Action run](https://github.com/sparkbox/sparkpress-wordpress-starter/actions/runs/6267438816/job/17020498793), confirming that despite our lack of any existing releases or a changelog, it was able to run successfully