### PR TITLE
chore: add PR template

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,0 +1,18 @@
+## Description
+
+<!-- Add a description of work done here -->
+
+<!-- If using GitHub issues, set the issue number to close it on merge -->
+Closes #ISSUE_NUMBER
+
+<!-- If using external project management, link to the issue/specification -->
+<!-- [Issue](https://example.com/ISSUE_NUMBER) -->
+
+## To Validate
+
+<!-- Add steps a reviewer should follow to validate your changes -->
+
+1. Make sure all PR Checks have passed
+2. Pull down this branch
+3. Run `npm start`
+<!-- Add additional validation steps here -->


### PR DESCRIPTION
## Description

This adds a PR template to make PR descriptions and validation steps more consistent without making the format too rigid. Since this is a starter template, the comments describe linking to external project management tools instead of the GitHub-style method that references the issue number.

Closes #35 

## To Validate

Ironically, this can't be validated until after it is merged, but confirm that the contents of the template work for what we want.