### PR TITLE
feat: support password protected posts

### DIFF
--- a/src/php/archive.php
+++ b/src/php/archive.php
@@ -3,11 +3,6 @@
  * The template for displaying archive pages
  */
 
-$page_num = get_query_var( 'paged' );
-$page_num = empty( $page_num ) ? 1 : $page_num;
-$posts_per_page = 12;
-$count = $GLOBALS['wp_query']->post_count;
-
 $templates = array( 'archive.twig', 'index.twig' );
 
 $context = Timber\Timber::context();

--- a/src/php/example-page-template.php
+++ b/src/php/example-page-template.php
@@ -8,4 +8,4 @@ $timber_post = new Timber\Post();
 $context['post'] = $timber_post;
 
 // Render HTML templates.
-Timber\Timber::render( 'pages/example-page.twig', $context );
+render_with_password_protection( $timber_post, 'pages/example-page.twig', $context );

--- a/src/php/functions.php
+++ b/src/php/functions.php
@@ -78,6 +78,21 @@ require get_template_directory() . '/inc/class-sparkpress-walker.php';
 function add_to_context( $context ) {
 	$context['menu'] = new \Timber\Menu( 'primary-menu' );
 	$context['footer_sidebar'] = Timber\Timber::get_widgets( 'footer-area' );
-    return $context;
+	return $context;
 }
 add_filter( 'timber/context', 'add_to_context' );
+
+/**
+ * Render page content with password protection.
+ *
+ * @param object $post - The current post.
+ * @param string|array $templates - The template(s) to render.
+ * @param object $context - The Timber context used to render.
+ */
+function render_with_password_protection( $post, $templates, $context ) {
+	if ( post_password_required( $post->ID ) ) {
+		Timber::render( 'single-password.twig', $context );
+	} else {
+		Timber::render( $templates, $context );
+	}
+}

--- a/src/php/functions.php
+++ b/src/php/functions.php
@@ -85,9 +85,9 @@ add_filter( 'timber/context', 'add_to_context' );
 /**
  * Render page content with password protection.
  *
- * @param object $post - The current post.
+ * @param object       $post - The current post.
  * @param string|array $templates - The template(s) to render.
- * @param object $context - The Timber context used to render.
+ * @param object       $context - The Timber context used to render.
  */
 function render_with_password_protection( $post, $templates, $context ) {
 	if ( post_password_required( $post->ID ) ) {
@@ -96,3 +96,18 @@ function render_with_password_protection( $post, $templates, $context ) {
 		Timber::render( $templates, $context );
 	}
 }
+
+/**
+ * Filter password protected posts out of listing page queries.
+ *
+ * @param object $query - The incoming query.
+ * @return object
+ */
+function filter_password_protected_posts( $query ) {
+	if ( ! $query->is_admin && ! $query->is_single ) {
+		$query->set( 'has_password', false );
+	}
+
+	return $query;
+}
+add_filter( 'pre_get_posts', 'filter_password_protected_posts' );

--- a/src/php/page.php
+++ b/src/php/page.php
@@ -14,4 +14,6 @@
 $context           = Timber\Timber::context();
 $timber_post       = new Timber\Post();
 $context['post']   = $timber_post;
-Timber\Timber::render( array( 'page-' . $timber_post->post_name . '.twig', 'page.twig' ), $context );
+$templates         = array( 'page-' . $timber_post->post_name . '.twig', 'page.twig' );
+
+render_with_password_protection( $timber_post, $templates, $context );

--- a/src/php/search.php
+++ b/src/php/search.php
@@ -7,7 +7,9 @@
  */
 
 $context          = Timber\Timber::context();
-$context['title'] = 'Search results for ' . get_search_query();
+
+$search_term = get_search_query();
+$context['title'] = 'Search results for ' . $search_term;
 $context['posts'] = new Timber\PostQuery();
 
 Timber\Timber::render( 'search.twig', $context );

--- a/src/php/single-example.php
+++ b/src/php/single-example.php
@@ -7,4 +7,6 @@
 $context           = Timber\Timber::context();
 $timber_post       = new Timber\Post();
 $context['post']   = $timber_post;
-Timber\Timber::render( array( 'page-' . $timber_post->post_name . '.twig', 'page.twig' ), $context );
+$templates         = array( 'page-' . $timber_post->post_name . '.twig', 'page.twig' );
+
+Timber\Timber::render( $timber_post, $templates, $context );

--- a/src/php/single.php
+++ b/src/php/single.php
@@ -9,4 +9,6 @@
 $context           = Timber\Timber::context();
 $timber_post       = new Timber\Post();
 $context['post']   = $timber_post;
-Timber\Timber::render( array( 'page-' . $timber_post->post_name . '.twig', 'page.twig' ), $context );
+$templates         = array( 'page-' . $timber_post->post_name . '.twig', 'page.twig' );
+
+render_with_password_protection( $timber_post, $templates, $context );

--- a/src/php/views/single-password.twig
+++ b/src/php/views/single-password.twig
@@ -1,0 +1,7 @@
+{% extends "base.twig" %}
+
+{% block content %}
+  <div class="obj-width-limiter">
+    {{ function('get_the_password_form') }}
+  </div>
+{% endblock %}

--- a/wp-configs/.htaccess
+++ b/wp-configs/.htaccess
@@ -2,14 +2,6 @@
 # The directives (lines) between "BEGIN WordPress" and "END WordPress" are
 # dynamically generated, and should only be modified via WordPress filters.
 # Any changes to the directives between these markers will be overwritten.
-<IfModule mod_rewrite.c>
-RewriteEngine On
-RewriteBase /
-RewriteRule ^index\.php$ - [L]
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteRule . /index.php [L]
-</IfModule>
 
 # END WordPress
 


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->
This work adds the required logic and templates to support password protected posts and pages. The newly established pattern is to use the `render_with_password_protection` function on any single post page, which will render the `single-password.twig` template if a password is required. For listing pages, a filter was added to set `has_password` to true for non-admin queries.

<!-- If using GitHub issues, set the issue number to close it on merge -->
Closes #48 

<!-- If using external project management, link to the issue/specification -->
<!-- [Issue](https://example.com/ISSUE_NUMBER) -->

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Add enough varied test posts to validate when they are or aren't being shown in listing pages
5. In the WordPress editor for one or more posts, set the visibility to "Password protected", and publish the post
6. View the post and confirm that you need to enter a password to see the page
7. Do the same for a Page, such as the "Sample page" that's added when you first initialize WordPress
8. Check the listing pages to make sure the password protected posts aren't shown, including:
    1. The home page
    2. The search page (`?s=search+term`)
    3. Category pages (`?cat=1`)
9. Change the password protected posts to be "Public" and confirm that they don't require passwords on the pages themselves and that they are shown in listing pages
<!-- Add additional validation steps here -->
