### PR TITLE
chore: bump mysql image version to 8.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - ./.env:/var/www/html/.env
       - ./wp-configs/.htaccess:/var/www/html/.htaccess
   db:
-    image: mysql:5.7
+    image: mysql:8.1
     container_name: sparkpress_db
     restart: always
     ports:


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->
This bumps the MySQL version used by `sparkpress_db` to 8.1, which is [compatible with WordPress 6.3](https://make.wordpress.org/hosting/handbook/compatibility/).

<!-- If using GitHub issues, set the issue number to close it on merge -->
Closes #27

<!-- If using external project management, link to the issue/specification -->
<!-- [Issue](https://example.com/ISSUE_NUMBER) -->

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Stop your running containers (`docker compose down`)
4. You may want to delete your images and volumes, but that may not be necessary
5. Run `docker compose build`
6. Run `npm start`
7. Visit http://localhost:8000 and confirm that the typical WordPress installation works as expected (or your site works as expected if you didn't delete your DB volume)
8. Download this [DB export](https://github.com/sparkbox/sparkpress-wordpress-starter/files/12731454/db-export-2023-09-26T19-55-14_UTC.sql.gz) and put it in a top-level `sql` folder
9. Run `npm run import-db`
10. Visit http://localhost:8000 and confirm that there is a post titled "MySQL 8.1 Test" and that the site works normally
<!-- Add additional validation steps here -->

