### PR TITLE
refactor: use generic environment variable example to avoid confusion

### DIFF
--- a/src/php/inc/helpers/generic.php
+++ b/src/php/inc/helpers/generic.php
@@ -7,8 +7,9 @@
  * Define Globals for within Theme.
  */
 function define_theme_globals() {
+	// Define your own site-specific environment variables here.
 	// phpcs:ignore
-	define( 'GOOGLE_API_KEY', $_SERVER['GOOGLE_API_KEY'] ?? '' );
+	define( 'CUSTOM_ENVIRONMENT_VARIABLE', $_SERVER['CUSTOM_ENVIRONMENT_VARIABLE'] ?? '' );
 }
 add_filter( 'init', 'define_theme_globals' );
 


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->
The `GOOGLE_API_KEY` example for loading an environment variable could lead to confusion, since a developer could reasonably expect that it was wired up to a tag manager/analytics script, then be surprised that it didn't do anything. This replaces that key with something that's more clearly an example and includes a comment to reinforce that it's an example.

<!-- If using GitHub issues, set the issue number to close it on merge -->
Closes #54

<!-- If using external project management, link to the issue/specification -->
<!-- [Issue](https://example.com/ISSUE_NUMBER) -->

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Make sure your site still works as expected (the change shouldn't change any behavior)
<!-- Add additional validation steps here -->
