### PR TITLE
fix: force create plugin folder on pantheon deploy

### DIFF
--- a/.github/workflows/deploy.pantheon.yml
+++ b/.github/workflows/deploy.pantheon.yml
@@ -59,6 +59,8 @@ jobs:
           rm -rf prod/vendor prod/wp-content/plugins prod/wp-content/themes/sparkpress
           cp -r vendor prod
           cp -r theme prod/wp-content/themes/sparkpress
+          # create plugins directory if it doesn't exist
+          mkdir -p wp-content/plugins
           cp -r wp-content/plugins prod/wp-content/plugins
 
       - name: Deploy to Pantheon


### PR DESCRIPTION
## Description

If no WordPress plugins are installed through composer, `wp-content/plugins` does not exist for build. To prevent build from failing, force creation of the folder if it doesn't exist.

## To Validate

1. View failed Pantheon deployment log, dispatched from `main`.
2. https://github.com/sparkbox/sparkpress-wordpress-starter/actions/runs/6318195516
3. Note that it fails due to missing `wp-content/plugins` folder. This folder is created via `composer install`, but only if the composer deps are WordPress plugins. Since we removed the WordPress plugins from `composer.json`, this folder no longer gets created. 
4. View [successful Pantheon deployment log](https://github.com/sparkbox/sparkpress-wordpress-starter/actions/runs/6318462690/job/17157489584), dispatched from this branch. `mkdir -p` will create the directory only when it doesn't exist, and will not fail if the folder already exists.
