### PR TITLE
fix: install plugin dependencies in deployment workflow

### DIFF
--- a/.github/workflows/deploy.pantheon.yml
+++ b/.github/workflows/deploy.pantheon.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
+      - name: Install custom plugin npm dependencies
+        run: npm run plugins:install
+
       - name: Install PHP dependencies with Composer
         uses: php-actions/composer@v6
         with:


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->

This fixes our deployment workflow, which is missing the step to install plugin dependencies, causing the [build to fail](https://github.com/sparkbox/sparkpress-wordpress-starter/actions/runs/6341504130/job/17225287279).

<!-- If using GitHub issues, set the issue number to close it on merge -->


<!-- If using external project management, link to the issue/specification -->
<!-- [Issue](https://example.com/ISSUE_NUMBER) -->

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm ci`
4. Run `npm run plugins:install`
5. Run `npm run build:prod`
6. Confirm that each of these steps ran successfully and compare them to the deployment workflow, which should effectively do the same thing
<!-- Add additional validation steps here -->
