### PR TITLE
Chore: add twig extensions

### DIFF
--- a/docs/structure.md
+++ b/docs/structure.md
@@ -23,7 +23,7 @@ The `php/` directory holds the PHP template files for the WordPress theme. Other
 	- `shortcodes/*.php` - Add shortcodes for the content editor to use
 	- `helpers/*.php` - Add helper functions here, separated by purpose
 	- `theme-scripts.php` - Add CSS and JavaScript files here.
-- `template-parts/` - WordPress provides "Template Parts" which can be thought of as "Components". To use the template part you should utilize the `get_template_part` function provided by WordPress ([docs][template]).
+- `views/` - [Twig][twig] is used to separate presentation from logic, and all `.twig` components can be found here. Some Twig extensions, notably [HTML Extension][html-extension] and [String Extension][string-extension] have been added to enhance templates with data URIs, class management, text manipulation, and ASCII-safe string transformations.
 
 [babel]:https://babeljs.io
 [node]:https://nodejs.org/en/
@@ -31,5 +31,7 @@ The `php/` directory holds the PHP template files for the WordPress theme. Other
 [sb-stylelint]:https://github.com/sparkbox/stylelint-config-sparkbox
 [wpcs]:https://github.com/WordPress/WordPress-Coding-Standards
 [bemit]:https://csswizardry.com/2015/08/bemit-taking-the-bem-naming-convention-a-step-further/
-[template]:https://developer.wordpress.org/reference/functions/get_template_part/
+[twig]:https://twig.symfony.com/
+[html-extension]:https://github.com/twigphp/html-extra
+[string-extension]:https://github.com/twigphp/string-extra
 [underscores]:https://underscores.me/

--- a/src/php/functions.php
+++ b/src/php/functions.php
@@ -8,6 +8,8 @@
 /**
  * Twig / Timber templating.
  */
+use Twig\Extra\String\StringExtension;
+use Twig\Extra\Html\HtmlExtension;
 $timber = new Timber\Timber();
 
 /**
@@ -81,6 +83,22 @@ function add_to_context( $context ) {
 	return $context;
 }
 add_filter( 'timber/context', 'add_to_context' );
+
+/**
+ * Adds Twig extensions to the Twig environment to enhance functionality:
+ * Adds StringExtension (string-extra).
+ * Adds HtmlExtension (html-extra).
+ *
+ * @param \Twig\Environment $twig - The Twig environment to which extensions are added.
+ * @return \Twig\Environment The Twig environment with added extensions.
+ */
+function add_to_twig( $twig ) {
+	$twig->addExtension( new StringExtension() );
+	$twig->addExtension( new HtmlExtension() );
+    return $twig;
+}
+
+add_filter( 'timber/twig', 'add_to_twig' );
 
 /**
  * Render page content with password protection.

--- a/src/php/views/base.twig
+++ b/src/php/views/base.twig
@@ -1,10 +1,10 @@
 {% include 'header.twig' %}
 
-		<article id="post-{{ post.id }}" role="main" class="post-type-{{ post.post_type }} {{ function('post_class') }}">
+		<article id="post-{{ post.id }}" role="main" class="post-type-{{ post.post_type }} {{ function('get_post_class')|join(' ') }}">
 
 			{% if post.title %}
         <div class="obj-width-limiter">
-          {# equivelant to the_title() #}
+          {# equivalent to the_title() #}
           <h1>{{ post.title }}</h1>
         </div>
       {% endif %}


### PR DESCRIPTION
## Description

This adds extensions to Twig so that they can be used in Twig components.

Also includes a quick fix to adjust a class attribute with incorrect syntax, see screen shot below from `main` branch:
<img width="507" alt="Screenshot 2023-09-28 at 1 48 22 PM" src="https://github.com/sparkbox/sparkpress-wordpress-starter/assets/54716846/398155a0-a2f4-42a7-97d2-49ecf254f944">

<!-- If using GitHub issues, set the issue number to close it on merge -->
Closes #57 

<!-- If using external project management, link to the issue/specification -->
<!-- [Issue](https://example.com/ISSUE_NUMBER) -->

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch but check out one commit back to view the test commit showing that extensions are working properly: `git checkout HEAD~1`
3. Run `npm start`
4. In your own database, create a post that does have comments allowed and one that does not, or use this db export: 
[twig-extension-test-db-2023-09-28T21-40-37_UTC.sql.gz](https://github.com/sparkbox/sparkpress-wordpress-starter/files/12754603/twig-extension-test-db-2023-09-28T21-40-37_UTC.sql.gz)
5. Navigate to the post with comments turned on, and the one with comments turned off, confirm that `html_classes` filter (part of `html_extra` extension) is working correctly and is applying classes conditionally.
6. Confirm that `slug` filter (`string_extra` extension) is working correctly, instead of the `Çömmêñtš` text used in `page.twig`, it should display in the posts as `Comments`
7. Look over documentation to see that it seems accurate and provides enough information about the added Twig extensions.
8. From any page, inspect the `article` tag inside the `main` tag. Note that the class names appear to be appropriately applied, unlike the example above.
<!-- Add additional validation steps here -->
