### PR TITLE
chore: delete default plugins on install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN cd /tmp \
   && wget http://wordpress.org/wordpress-${WP_VERSION}.zip \
   && unzip wordpress-${WP_VERSION}.zip \
       && rm -rf /tmp/wordpress/wp-content/themes/* \
+      && rm -rf /tmp/wordpress/wp-content/plugins/* \
   && cp -avr /tmp/wordpress/* /var/www/html/. \
   && rm -rf /tmp/wordpress /tmp/wordpress-${WP_VERSION}.zip
 


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->
This change deletes the plugins that are automatically included with the WordPress installation. This removes the noise of unused plugins and their alerts about available updates.

<!-- If using GitHub issues, set the issue number to close it on merge -->
Closes #58 

<!-- If using external project management, link to the issue/specification -->
<!-- [Issue](https://example.com/ISSUE_NUMBER) -->

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Stop your running containers (`docker compose down`)
4. Run `docker compose build`
5. Run `npm start`
6. Navigate to the Plugins page in the WP admin and confirm that only our "Example Blocks" plugin is shown
<!-- Add additional validation steps here -->
