### PR TITLE
fix: minor accessibility issues

### DIFF
--- a/src/php/index.php
+++ b/src/php/index.php
@@ -12,9 +12,10 @@
 
 $context          = Timber\Timber::context();
 $context['posts'] = new Timber\PostQuery();
-$context['foo']   = 'bar';
 $templates        = array( 'index.twig' );
 if ( is_home() && ! is_front_page() ) {
 	$context['title'] = single_post_title();
+} else {
+	$context['title'] = 'Recent Posts';
 }
 Timber\Timber::render( $templates, $context );

--- a/src/php/views/base.twig
+++ b/src/php/views/base.twig
@@ -1,26 +1,26 @@
 {% include 'header.twig' %}
 
-		<article id="post-{{ post.id }}" role="main" class="post-type-{{ post.post_type }} {{ function('get_post_class')|join(' ') }}">
+<article id="post-{{ post.id }}" class="post-type-{{ post.post_type }} {{ function('get_post_class')|join(' ') }}">
 
-			{% if post.title %}
-        <div class="obj-width-limiter">
-          {# equivalent to the_title() #}
-          <h1>{{ post.title }}</h1>
-        </div>
-      {% endif %}
+	{% if post.title %}
+		<div class="obj-width-limiter">
+			{# equivalent to the_title() #}
+			<h1>{{ post.title }}</h1>
+		</div>
+	{% endif %}
 
-      {# content block from child templates #}
-      {% block content %}
-        <div class="obj-width-limiter">
-          Sorry, no content
-        </div>
-      {% endblock %}
+	{# content block from child templates #}
+	{% block content %}
+		<div class="obj-width-limiter">
+			Sorry, no content
+		</div>
+	{% endblock %}
 
-      {% if sidebar %}
-				<aside>
-					{{ sidebar }}
-				</aside>
-			{% endif %}
-		</article>
+	{% if sidebar %}
+		<aside>
+			{{ sidebar }}
+		</aside>
+	{% endif %}
+</article>
 
 {% include 'footer.twig' %}

--- a/src/php/views/header.twig
+++ b/src/php/views/header.twig
@@ -1,36 +1,39 @@
 <!doctype html>
 <html {{ site.language_attributes }} class="no-js safe-focus">
-<head>
-  <meta charset="{{ site.charset }}" />
-  <meta name="description" content="{{ site.description }}">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="profile" href="https://gmpg.org/xfn/11">
-  {{ function('wp_head') }}
-</head>
-<body {{ body_class }}>
-  {{ function('wp_body_open') }}
-  <div class="obj-page">
+	<head>
+		<meta charset="{{ site.charset }}"/>
+		<meta name="description" content="{{ site.description }}">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<link rel="profile" href="https://gmpg.org/xfn/11">
+		{{ function('wp_head') }}
+	</head>
+	<body {{ body_class }}>
+		{{ function('wp_body_open') }}
+		<div class="obj-page">
 
-    <div class="obj-width-limiter">
-      <a class="cmp-skip-to-content" href="#main">Skip to content</a>
-      <a class="cmp-skip-to-content" href="#nav">Skip to navigation</a>
-    </div>
+			<div class="obj-width-limiter">
+				<a class="cmp-skip-to-content" href="#main">Skip to content</a>
+				<a class="cmp-skip-to-content" href="#nav">Skip to navigation</a>
+			</div>
 
-    <header class="cmp-header">
-      <div id="nav" class="obj-width-limiter">
+			<header class="cmp-header">
+				<div id="nav" class="obj-width-limiter">
 
-        {% block header %}
-          <div class="wrapper cmp-header">
-            <h1 class="cmp-header__logo" role="banner">
-              <a class="cmp-header__link" href="{{ site.url }}" rel="home">{{ site.name }}</a>
-            </h1>
-            <nav id="nav-main" class="nav-main" role="navigation">
-              {# replaces wp_nav_menu() #}
-              {% include "menu.twig" with {'items': menu.get_items} %}
-            </nav><!-- #nav -->
-          </div>
-        {% endblock %}
-      </div>
-    </header><!-- .cmp-header -->
+					{% block header %}
+						<div class="wrapper cmp-header">
+							<div class="cmp-header__logo">
+								<a class="cmp-header__link" href="{{ site.url }}" rel="home">{{ site.name }}</a>
+							</div>
+							<nav
+								id="nav-main" class="nav-main" aria-label="Main">
+								{# replaces wp_nav_menu() #}
+								{% include "menu.twig" with {'items': menu.get_items} %}
+							</nav>
+							<!-- #nav -->
+						</div>
+					{% endblock %}
+				</div>
+			</header>
+			<!-- .cmp-header -->
 
-    <main id="main">
+			<main id="main">

--- a/src/php/views/menu.twig
+++ b/src/php/views/menu.twig
@@ -1,20 +1,18 @@
 {% if menu %}
-<nav>
-    <ul class="nav-main">
-        {% for item in menu.items %}
-            <li class="nav-main-item {{ item.classes|join(' ') }}">
-                <a class="cmp-menu__link" href="{{ item.link }}">{{ item.title }}</a>
-                {% if item.children %}
-                    <ul class="nav-drop">
-                        {% for child in item.children %}
-                            <li class="nav-drop-item">
-                                <a href="{{ child.link }}">{{ child.title }}</a>
-                            </li>
-                        {% endfor %}
-                    </ul>
-                {% endif %}
-            </li>
-        {% endfor %}
-    </ul>
-</nav>
+	<ul class="nav-main">
+		{% for item in menu.items %}
+			<li class="nav-main-item {{ item.classes|join(' ') }}">
+				<a class="cmp-menu__link" href="{{ item.link }}">{{ item.title }}</a>
+				{% if item.children %}
+					<ul class="nav-drop">
+						{% for child in item.children %}
+							<li class="nav-drop-item">
+								<a href="{{ child.link }}">{{ child.title }}</a>
+							</li>
+						{% endfor %}
+					</ul>
+				{% endif %}
+			</li>
+		{% endfor %}
+	</ul>
 {% endif %}

--- a/src/php/views/partials/content-search.twig
+++ b/src/php/views/partials/content-search.twig
@@ -1,8 +1,8 @@
 <article id="post-{{ post.id }}" class="util-padding-bottom-md">
-	<h4>
+	<h2>
 		<a href="{{ post.link }}">{{ post.title }}</a>
-	</h4>
+	</h2>
 	<div>
-    {{ post.preview ? post.preview : post.content }}
+		{{ post.preview ? post.preview : post.content }}
 	</div>
 </article>

--- a/src/php/views/partials/content-single.twig
+++ b/src/php/views/partials/content-single.twig
@@ -1,8 +1,8 @@
 <article id="post-{{ post.id }}" class="util-padding-bottom-md">
-	<h4>
+	<h2>
 		{{ post.title }}
-	</h4>
+	</h2>
 	<div class="util-padding-b-md">
-    {{ post.preview }}
+		{{ post.preview }}
 	</div>
 </article>

--- a/src/php/views/partials/pagination.twig
+++ b/src/php/views/partials/pagination.twig
@@ -1,64 +1,64 @@
 {% if posts.pagination.pages is not empty %}
-    <nav>
-        <ul>
+	<nav aria-label="Pagination">
+		<ul>
 
-            {# First #}
-            {% if posts.pagination.pages|first and posts.pagination.pages|first.current != true %}
-                <li class="first btn">
-                    <a href="{{ posts.pagination.pages|first.link }}">First</a>
-                </li>
-            {% else %}
-                <li class="first btn disabled">
-                    <button disabled>First</button>
-                </li>
-            {% endif %}
+			{# First #}
+			{% if posts.pagination.pages|first and posts.pagination.pages|first.current != true %}
+				<li class="first btn">
+					<a href="{{ posts.pagination.pages|first.link }}">First</a>
+				</li>
+			{% else %}
+				<li class="first btn disabled">
+					<button disabled>First</button>
+				</li>
+			{% endif %}
 
-            {# Previous #}
-            {% if posts.pagination.prev %}
-                <li class="prev btn">
-                    <a href="{{ posts.pagination.prev.link }}">Previous</a>
-                </li>
-            {% else %}
-                <li class="prev btn disabled">
-                    <button disabled>Previous</button>
-                </li>
-            {% endif %}
+			{# Previous #}
+			{% if posts.pagination.prev %}
+				<li class="prev btn">
+					<a href="{{ posts.pagination.prev.link }}">Previous</a>
+				</li>
+			{% else %}
+				<li class="prev btn disabled">
+					<button disabled>Previous</button>
+				</li>
+			{% endif %}
 
-            {# Pages #}
-            {% for page in posts.pagination.pages %}
-                {% if page.link %}
-                    <li>
-                        <a href="{{ page.link }}" class="{{ page.class }}">{{ page.title }}</a>
-                    </li>
-                {% else %}
-                    <li class="current">
-                        <span class="{{ page.class }}">{{ page.title }}</span>
-                    </li>
-                {% endif %}
-            {% endfor %}
+			{# Pages #}
+			{% for page in posts.pagination.pages %}
+				{% if page.link %}
+					<li>
+						<a href="{{ page.link }}" class="{{ page.class }}">{{ page.title }}</a>
+					</li>
+				{% else %}
+					<li class="current">
+						<span class="{{ page.class }}">{{ page.title }}</span>
+					</li>
+				{% endif %}
+			{% endfor %}
 
-            {# Next #}
-            {% if posts.pagination.next %}
-                <li class="next btn">
-                    <a href="{{ posts.pagination.next.link }}">Next</a>
-                </li>
-            {% else %}
-                <li class="next btn disabled">
-                    <button disabled>Next</button>
-                </li>
-            {% endif %}
+			{# Next #}
+			{% if posts.pagination.next %}
+				<li class="next btn">
+					<a href="{{ posts.pagination.next.link }}">Next</a>
+				</li>
+			{% else %}
+				<li class="next btn disabled">
+					<button disabled>Next</button>
+				</li>
+			{% endif %}
 
-            {# Last #}
-            {% if posts.pagination.pages|last and posts.pagination.pages|last.current != true %}
-                <li class="last btn">
-                    <a href="{{ posts.pagination.pages|last.link }}">Last</a>
-                </li>
-            {% else %}
-                <li class="last btn disabled">
-                    <button disabled>Last</button>
-                </li>
-            {% endif %}
+			{# Last #}
+			{% if posts.pagination.pages|last and posts.pagination.pages|last.current != true %}
+				<li class="last btn">
+					<a href="{{ posts.pagination.pages|last.link }}">Last</a>
+				</li>
+			{% else %}
+				<li class="last btn disabled">
+					<button disabled>Last</button>
+				</li>
+			{% endif %}
 
-        </ul>
-    </nav>
+		</ul>
+	</nav>
 {% endif %}


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->
This fixes a handful of accessibility issues that are not necessarily blockers, but not ideal. That includes:

- Removing improper ARIA roles
- Adding `aria-label` to different `nav` elements to distinguish between them
- Fixing up the accessibility tree
- Updating heading levels so that the home page link is not the `h1` and that we don't skip straight to `h4`

<!-- If using GitHub issues, set the issue number to close it on merge -->
Closes #69 

<!-- If using external project management, link to the issue/specification -->
<!-- [Issue](https://example.com/ISSUE_NUMBER) -->

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Go through all non-admin pages and run Lighthouse and/or axe DevTools on each page, confirming that there are no automatically detected issues
5. Inspect the accessibility tree and confirm that the document is structured in a way that makes sense and that elements have the roles and accessible names that you would expect
<!-- Add additional validation steps here -->
