### PR TITLE
fix: update menu usage

### DIFF
--- a/src/php/functions.php
+++ b/src/php/functions.php
@@ -73,7 +73,7 @@ require get_template_directory() . '/inc/theme-scripts.php';
  * @return array
  */
 function add_to_context( $context ) {
-	$context['menu'] = new \Timber\Menu( 'primary-menu' );
+	$context['menu'] = new \Timber\Menu( 'primary' );
 	$context['footer_sidebar'] = Timber\Timber::get_widgets( 'footer-area' );
 	return $context;
 }

--- a/src/php/inc/theme-setup.php
+++ b/src/php/inc/theme-setup.php
@@ -34,7 +34,12 @@ if ( ! function_exists( 'sparkpress_theme_setup' ) ) :
 		 */
 		add_theme_support( 'post-thumbnails' );
 
-		register_nav_menus( array( 'primary' => 'Primary' ) );
+		register_nav_menus(
+			array(
+				'primary' => 'Primary',
+				// register additional menus
+			)
+		);
 
 		/*
 		 * Switch default core markup for search form, comment form, and comments

--- a/src/php/views/header.twig
+++ b/src/php/views/header.twig
@@ -22,7 +22,7 @@
 							<a href="{{ site.url }}" class="cmp-main-nav__home-link" rel=" home">{{ site.name }}</a>
 						</div>
 						<nav class="cmp-main-nav__menu" aria-label="Main">
-							{% include "menu.twig" with {'items': menu.get_items} %}
+							{% include "menu.twig" %}
 						</nav>
 					</div>
 				{% endblock %}

--- a/src/php/views/menu.twig
+++ b/src/php/views/menu.twig
@@ -1,3 +1,4 @@
+{# can specify menu when including template #}
 {% if menu %}
 	<ul class="cmp-main-nav__list">
 		{% for item in menu.items %}


### PR DESCRIPTION
## Description

Makes some minor fixes to the registration and usage of menus:
- Adds comments to clarify how multiple menus could be used when registering menus and in `menu.twig` template.
- Removes unused items variable from menu include - this wasn't hurting anything, but also wasn't needed because we are getting menu items in a different way in the menu template.
- Changes argument when Timber Menu is instantiated to use correct menu. This also wasn't hurting anything because we [only have one menu so the argument is optional](https://timber.github.io/docs/reference/timber-menu/#__construct), but would become a problem if anyone wanted to add an additional menu to the existing code.

<!-- If using GitHub issues, set the issue number to close it on merge -->
Closes #77 

<!-- If using external project management, link to the issue/specification -->
<!-- [Issue](https://example.com/ISSUE_NUMBER) -->

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Confirm that this has no negative effects on the way menus currently work: the 'Primary' menu location still exists in the wp-admin and menu displays as before (if your DB does not have a menu, you can use the one from #73 ).
5. Confirm that changes and comments make sense and are appropriate for someone wanting to make updates to menus.
<!-- Add additional validation steps here -->
