### PR TITLE
feat: support multiple sidebars

### DIFF
--- a/src/php/functions.php
+++ b/src/php/functions.php
@@ -74,7 +74,6 @@ require get_template_directory() . '/inc/theme-scripts.php';
  */
 function add_to_context( $context ) {
 	$context['menu'] = new \Timber\Menu( 'primary' );
-	$context['footer_sidebar'] = Timber\Timber::get_widgets( 'footer-area' );
 	return $context;
 }
 add_filter( 'timber/context', 'add_to_context' );

--- a/src/php/inc/theme-widgets.php
+++ b/src/php/inc/theme-widgets.php
@@ -6,14 +6,26 @@
  */
 
 /**
- * Register widget area.
+ * Register widgetized areas.
  */
 function sparkpress_theme_widgets_init() {
 	register_sidebar(
 		array(
+			'name'          => 'Primary Widget Area',
+			'id'            => 'primary-widget-area',
+			'description'   => 'Primary sidebar area on the side of the page.',
+			'before_widget' => '<div>',
+			'after_widget'  => '</div>',
+			'before_title'  => '<h3>',
+			'after_title'   => '</h3>',
+		)
+	);
+
+	register_sidebar(
+		array(
 			'name'          => 'Footer',
 			'id'            => 'footer-area',
-			'description'   => 'Sidebar for a the footer area.',
+			'description'   => 'Sidebar for the footer area.',
 			'before_widget' => '<div>',
 			'after_widget'  => '</div>',
 			'before_title'  => '<h3>',

--- a/src/php/inc/theme-widgets.php
+++ b/src/php/inc/theme-widgets.php
@@ -11,13 +11,11 @@
 function sparkpress_theme_widgets_init() {
 	register_sidebar(
 		array(
-			'name'          => 'Primary Widget Area',
-			'id'            => 'primary-widget-area',
-			'description'   => 'Primary sidebar area on the side of the page.',
+			'name'          => 'Primary Sidebar',
+			'id'            => 'primary-sidebar',
+			'description'   => 'Widget for the sidebar area.',
 			'before_widget' => '<div>',
 			'after_widget'  => '</div>',
-			'before_title'  => '<h3>',
-			'after_title'   => '</h3>',
 		)
 	);
 
@@ -25,12 +23,23 @@ function sparkpress_theme_widgets_init() {
 		array(
 			'name'          => 'Footer',
 			'id'            => 'footer-area',
-			'description'   => 'Sidebar for the footer area.',
+			'description'   => 'Widget for the footer area.',
 			'before_widget' => '<div>',
 			'after_widget'  => '</div>',
-			'before_title'  => '<h3>',
-			'after_title'   => '</h3>',
 		)
 	);
 }
 add_action( 'widgets_init', 'sparkpress_theme_widgets_init' );
+
+/**
+ * Adds sidebar and footer widgets to the Timber context.
+ *
+ * @param array $context The Timber context array.
+ * @return array The updated Timber context array with sidebar and footer widgets.
+ */
+function sparkpress_add_widgets_to_context( $context ) {
+	$context['sidebar_widget'] = Timber\Timber::get_widgets( 'primary-sidebar' );
+	$context['footer_widget'] = Timber\Timber::get_widgets( 'footer-area' );
+	return $context;
+}
+add_filter( 'timber/context', 'sparkpress_add_widgets_to_context' );

--- a/src/php/views/base.twig
+++ b/src/php/views/base.twig
@@ -15,9 +15,9 @@
 				Sorry, no content
 			</div>
 		{% endblock %}
-		{% if primary_sidebar %}
+		{% if sidebar_widget %}
 			<aside class="obj-width-limiter cmp-primary-sidebar">
-				{{ primary_sidebar }}
+				{{ sidebar_widget }}
 			</aside>
 		{% endif %}
 	</div>

--- a/src/php/views/base.twig
+++ b/src/php/views/base.twig
@@ -14,10 +14,9 @@
 			Sorry, no content
 		</div>
 	{% endblock %}
-
-	{% if sidebar %}
+	{% if primary_sidebar %}
 		<aside>
-			{{ sidebar }}
+			{{ primary_sidebar }}
 		</aside>
 	{% endif %}
 </article>

--- a/src/php/views/base.twig
+++ b/src/php/views/base.twig
@@ -8,17 +8,19 @@
 		</div>
 	{% endif %}
 
-	{# content block from child templates #}
-	{% block content %}
-		<div class="obj-width-limiter">
-			Sorry, no content
-		</div>
-	{% endblock %}
-	{% if primary_sidebar %}
-		<aside>
-			{{ primary_sidebar }}
-		</aside>
-	{% endif %}
+	<div class="obj-width-limiter cmp-post-body">
+		{# content block from child templates #}
+		{% block content %}
+			<div class="obj-width-limiter">
+				Sorry, no content
+			</div>
+		{% endblock %}
+		{% if primary_sidebar %}
+			<aside class="obj-width-limiter cmp-primary-sidebar">
+				{{ primary_sidebar }}
+			</aside>
+		{% endif %}
+	</div>
 </article>
 
 {% include 'footer.twig' %}

--- a/src/php/views/footer.twig
+++ b/src/php/views/footer.twig
@@ -12,7 +12,7 @@
 				Privacy Policy
 			</a>
 		</p>
-		{{ footer_sidebar }}
+		{{ footer_widget }}
 	</div>
 </footer>
 

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -63,6 +63,8 @@
 //    Specific UI components. This is where majority of our work takes place
 //    and our UI components are often composed of Objects and Components
 @import 'components/main-nav';
+@import 'components/primary-sidebar';
+@import 'components/post-body';
 @import 'components/skip-to-content';
 @import 'components/sticky-footer';
 

--- a/src/scss/components/_post-body.scss
+++ b/src/scss/components/_post-body.scss
@@ -1,0 +1,8 @@
+.cmp-post-body {
+  display: flex;
+  flex-direction: column;
+  
+  @media (min-width: 50rem) {
+    flex-direction: row;
+  }
+}

--- a/src/scss/components/_post-body.scss
+++ b/src/scss/components/_post-body.scss
@@ -1,6 +1,7 @@
 .cmp-post-body {
   display: flex;
   flex-direction: column;
+  gap: 1.5rem 3.75rem;
   
   @media (min-width: 50rem) {
     flex-direction: row;

--- a/src/scss/components/_primary-sidebar.scss
+++ b/src/scss/components/_primary-sidebar.scss
@@ -1,10 +1,8 @@
 .cmp-primary-sidebar {
   background-color: var(--gray-background-color);
   padding: 1rem;
-  margin-top: 1.5rem;
   
   @media (min-width: 50rem) {
-    margin: 0 0 0 3.75rem;
-    width: 18.75rem;
+    flex-basis: 18.75rem;
   }
 }

--- a/src/scss/components/_primary-sidebar.scss
+++ b/src/scss/components/_primary-sidebar.scss
@@ -1,0 +1,10 @@
+.cmp-primary-sidebar {
+  background-color: var(--gray-background-color);
+  padding: 1rem;
+  margin-top: 1.5rem;
+  
+  @media (min-width: 50rem) {
+    margin: 0 0 0 3.75rem;
+    width: 18.75rem;
+  }
+}

--- a/src/scss/elements/_root.scss
+++ b/src/scss/elements/_root.scss
@@ -8,6 +8,9 @@
 	--black: hsl(0deg 0% 0%);
 	--white: hsl(0deg 0% 100%);
 
+	// Gray
+	--gray: hsl(0deg 0% 97%);
+
 	// Link colors
 	--link-color: var(--primary-color);
 	--link-color-hover: var(--secondary-color);
@@ -16,6 +19,7 @@
 	// Foreground/background colors
 	--text-color: var(--black);
 	--background-color: var(--white);
+	--gray-background-color: var(--gray);
 
 	color: var(--text-color);
 	background-color: var(--background-color);


### PR DESCRIPTION
## Description

Registers an additional sidebar area (`primary_sidebar`) to be used in the `<aside>` that was already built into the `base.twig` template. Adds minimal styling for the sidebar to visually distinguish it from other parts of the page.

<!-- If using GitHub issues, set the issue number to close it on merge -->
Addresses #75 

<!-- If using external project management, link to the issue/specification -->
<!-- [Issue](https://example.com/ISSUE_NUMBER) -->

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Navigate to localhost:8000, confirm that no widgets appear in the footer or the sidebar initially (if you've already opened widgets before, reset the db)
5. Navigate to wp-admin, then go to Appearance > Widgets. This automatically fills in registered widget areas with default content.
6. Check localhost:8000 again to confirm that the widgets appear on the page and check sidebar styling.
7. Review scss file additions to confirm that they make sense and follow conventions.
<!-- Add additional validation steps here -->
