### PR TITLE
chore: simplify docker npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "prestart": "run-p clean node-version",
     "start": "run-p build:dev serve:dev",
-    "postserve:dev": "docker-compose down",
     "clean": "rm -rf theme/ plugins/example-blocks/",
     "copy": "run-p copy:*",
     "copy:php": "mkdir -p ./theme && cp -r ./src/php/* ./theme",
@@ -15,7 +14,7 @@
     "prebuild:prod": "npm run clean",
     "build:dev": "run-p plugins:dev copy:php sass watch js:watch",
     "build:prod": "run-s plugins:build copy js:prod 'sass -- --style compressed'",
-    "serve:dev": "docker-compose up",
+    "serve:dev": "docker compose up --abort-on-container-exit || docker compose down",
     "sass": "sass src/scss/base.scss theme/css/base.css",
     "postsass": "postcss theme/css/base.css --use autoprefixer -r",
     "js:watch": "NODE_ENV=development node esbuild.mjs",


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->
This removes the `postserve:dev` script in favor of using the `--abort-on-container-exit` flag.

<!-- If using GitHub issues, set the issue number to close it on merge -->
Closes #12 

<!-- If using external project management, link to the issue/specification -->
<!-- [Issue](https://example.com/ISSUE_NUMBER) -->

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`, then Ctrl+C to stop the process (it should behave the same as it did before)
4. Run `npm run serve:dev`, then Ctrl+C to stop the process (it should spin down the containers and return you to a new command line)
<!-- Add additional validation steps here -->
