### PR TITLE
chore: configure dependabot for monthly npm/composer update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,48 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    groups:
+      npm-dev-dependencies:
+        dependency-type: 'development'
+        update-types:
+          - 'minor'
+          - 'patch'
+      npm-major-dev-dependencies:
+        dependency-type: 'development'
+        update-types:
+          - 'major'
+      npm-production-dependencies:
+        dependency-type: 'production'
+        update-types:
+          - 'minor'
+          - 'patch'
+      npm-major-production-dependencies:
+        dependency-type: 'production'
+        update-types:
+          - 'major'
+  - package-ecosystem: 'composer'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    groups:
+      composer-dev-dependencies:
+        dependency-type: 'development'
+        update-types:
+          - 'minor'
+          - 'patch'
+      composer-major-dev-dependencies:
+        dependency-type: 'development'
+        update-types:
+          - 'major'
+      composer-production-dependencies:
+        dependency-type: 'production'
+        update-types:
+          - 'minor'
+          - 'patch'
+      composer-major-production-dependencies:
+        dependency-type: 'production'
+        update-types:
+          - 'major'


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->
This sets up dependabot to create update PRs for npm/composer dependencies on a monthly schedule. To make the process of validating updates simple without risking unexpected breaking changes, the updates are grouped by minor/patch version vs. major version updates, by development vs. production dependencies, and by composer vs. npm dependencies.

[Here's a PR](https://github.com/sparkbox/accessible-components/pull/254) for another project for adding a very similar config, and here's an example [dependabot PR](https://github.com/sparkbox/accessible-components/pull/255) that updated all dev dependencies. The open question about this PR's config is whether Composer behaves the same way as npm.

<!-- If using GitHub issues, set the issue number to close it on merge -->
Closes #92 

<!-- If using external project management, link to the issue/specification -->
<!-- [Issue](https://example.com/ISSUE_NUMBER) -->

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. We can't validate what dependabot will do until this file is on `main`, but you can check the [configuration options](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file) to make sure our usage is valid
<!-- Add additional validation steps here -->
