### PR TITLE
feat: add generator for reusable patterns

### DIFF
--- a/docs/generators.md
+++ b/docs/generators.md
@@ -65,3 +65,17 @@ The following files will be created based on your input:
 - `src/php/views/<page-template-name>.twig`
 
 [Page Template documentation](https://developer.wordpress.org/themes/template-files-section/page-template-files/)
+
+## Reusable Pattern
+
+The generator for reusable patterns will prompt you for a name, description, and categories for the pattern, then create a script to register a reusable pattern with metadata based on your inputs and instructions for how to create the markup for the pattern.
+
+```sh
+npm run generate:pattern
+```
+
+The following file will be created based on your input:
+
+- `src/php/patterns/<pattern-name>.php`
+
+[Reusable pattern (a.k.a. Block pattern) documentation](https://developer.wordpress.org/themes/advanced-topics/block-patterns/)

--- a/generators/pattern.js
+++ b/generators/pattern.js
@@ -1,0 +1,130 @@
+const { writeFileSync, readFileSync } = require('fs');
+const { join } = require('path');
+const prompts = require('prompts');
+
+const getPatternScript = ({ patternSlug, themeSlug, description, categories }) => `<?php
+/**
+ * Title: ${description}
+ * Slug: ${themeSlug}/${patternSlug}
+ * Categories: ${categories.join(', ')}
+ */
+?>
+<!-- wp:paragraph -->
+<p>Replace this sample content with markup for a pattern.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:list -->
+<ul><!-- wp:list-item -->
+<li>Arrange whichever blocks you need to form the pattern in the WordPress editor</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Select all blocks (or the outermost block), the click the kebab menu > Copy (or Copy blocks)</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Paste the resulting content in ${patternSlug}.php</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list -->
+`;
+
+const getDetails = async () => {
+	const questions = [
+		{
+			type: 'text',
+			name: 'name',
+			message: 'What should the pattern be called? Content editors will search for this name.',
+		},
+		{
+			type: 'text',
+			name: 'description',
+			message:
+				'Please describe this pattern. This will help content editors understand what the pattern should be used for.',
+		},
+		{
+			type: 'multiselect',
+			name: 'categories',
+			message:
+				'Which pattern categories should this pattern be included in? This will help content editors find the pattern.',
+			hint: 'Space to select. Return to submit',
+			instructions: false,
+			choices: [
+				{
+					title: 'My patterns (recommended)',
+					value: 'custom',
+					selected: true,
+				},
+				{
+					title: 'Featured',
+					value: 'featured',
+					selected: false,
+				},
+				{
+					title: 'Posts',
+					value: 'posts',
+					selected: false,
+				},
+				{
+					title: 'Text',
+					value: 'text',
+					selected: false,
+				},
+				{
+					title: 'Gallery',
+					value: 'gallery',
+					selected: false,
+				},
+				{
+					title: 'Call to Action',
+					value: 'call-to-action',
+					selected: false,
+				},
+				{
+					title: 'Banners',
+					value: 'banner',
+					selected: false,
+				},
+				{
+					title: 'Headers',
+					value: 'header',
+					selected: false,
+				},
+				{
+					title: 'Footers',
+					value: 'footer',
+					selected: false,
+				},
+			],
+		},
+	];
+
+	const response = await prompts(questions);
+
+	return response;
+};
+
+const getFirstGroup = (regexp, str) =>
+	Array.from(str.matchAll(regexp), (match) => match[1])?.[0] ?? 'theme-slug';
+
+const getThemeSlug = () => {
+	const themeDefinitionPath = join(__dirname, '../src/php/style.css');
+	const themeDefinition = readFileSync(themeDefinitionPath, { encoding: 'utf-8' });
+
+	const themeSlug = getFirstGroup(/Theme Name:\s(.*)/gm, themeDefinition);
+
+	return themeSlug.toLowerCase().replace(/\W/g, '-');
+};
+
+const generatePattern = async () => {
+	const themeSlug = getThemeSlug();
+	const { name, description, categories } = await getDetails();
+	const patternSlug = name.toLowerCase().replace(/\W/g, '-');
+	const templateParams = { patternSlug, themeSlug, description, categories };
+
+	const patternScript = getPatternScript(templateParams);
+	const patternScriptPath = join(__dirname, '../src/php/patterns', `${patternSlug}.php`);
+	writeFileSync(patternScriptPath, patternScript, 'utf-8');
+	console.log(`Created ${patternScriptPath}`);
+};
+
+generatePattern();

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "import-db": "./scripts/import-db.sh",
     "preimport-db": "npm run backup-db",
     "generate:page-template": "node ./generators/page-template.js",
+    "generate:pattern": "node ./generators/pattern.js",
     "generate:post-type": "node ./generators/post-type.js",
     "generate:shortcode": "node ./generators/shortcode.js",
     "generate:taxonomy": "node ./generators/taxonomy.js",


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->

This adds a generator to register reusable patterns for WordPress editors to use. The template accepts metadata to make finding/understanding the pattern easier, and the sample markup provides both an example and instructions for how to get the markup needed for the pattern.

<!-- If using GitHub issues, set the issue number to close it on merge -->
Closes #95

<!-- If using external project management, link to the issue/specification -->
<!-- [Issue](https://example.com/ISSUE_NUMBER) -->

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Run `npm run generate:pattern` and answer the questions to create a test pattern
5. Confirm that a new file is added in the `src/php/patterns` directory with content corresponding to your answers to the prompts
6. Add or edit a post in the WP admin, and click the button to add a new block, then go to the Patterns tab
7. Confirm that you can find your new test pattern in the categories that you chose (create another pattern to test categories that you did/didn't select the first time)
8. Add the test pattern to the post and follow the instructions to replace the sample markup with something else
9. Update the `patterns/<pattern-name>.php` file with different markup, and confirm that the pattern is updated in the editor after you reload the page
<!-- Add additional validation steps here -->
