### PR TITLE
feat: support comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,31 @@ Most likely, you want your urls to be more user/SEO friendly, like `example.com/
 
 For other options see the [WordPress docs](https://wordpress.org/documentation/article/customize-permalinks/) for more info.
 
+### Comments
+
+Comments for posts are supported out of the box, but can be turned off for single posts or for any new posts going forward. Comments can be approved, edited, or trashed from the "Comments" menu from the admin dashboard.
+
+#### Turn off Comments on a Single Post
+
+1. From the admin dashboard, navigate to the "Edit Post" page
+1. Access the Post settings menu on the right side of the page, if it is not already open (the settings menu can be opened with the button to the right of the "Update" button)
+1. Scroll down the menu to the option with the heading "Discussion", uncheck "Allow comments" and update the post
+
+#### Turn off Comments on Future Posts
+
+This will uncheck "Allow comments" on individual posts going forward by default, but comments can be enabled for select posts.
+
+1. From the admin dashboard, click on "Discussion" under the "Settings" menu on the left side
+1. Under "Default post settings", uncheck "Allow people to submit comments on new posts"
+1. Scroll to the bottom and hit "Save Changes"
+
+#### Comments for Pages
+By default, comments are turned off for pages, but can be enabled for pages individually:
+
+1. From the admin dashboard, navigate to "Edit Page"
+1. Access the Page settings menu on the right side of the page
+1. Scroll down the menu to the option with the heading "Disucssion", check "Allow comments", and update the page
+
 ### Template Hierarchy
 
 This starter template covers the generic templates needed for things like single post pages, archive (or listing) pages, the 404 page, and the search page, but you can override those using [WordPress' template hierarchy](https://developer.wordpress.org/themes/basics/template-hierarchy/).

--- a/src/php/comments.php
+++ b/src/php/comments.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * The template for displaying comments.
+ *
+ * Loaded by comments_template().
+ *
+ * @link https://developer.wordpress.org/reference/functions/comments_template/
+ */
+
+// https://timber.github.io/docs/reference/timber/#context
+$context          = Timber\Timber::context();
+
+$context['should_show_avatars'] = get_option( 'show_avatars' );
+
+Timber\Timber::render( 'partials/comments.twig', $context );

--- a/src/php/inc/theme-setup.php
+++ b/src/php/inc/theme-setup.php
@@ -95,3 +95,33 @@ function custom_hide_editor() {
 	}
 }
 add_action( 'admin_init', 'custom_hide_editor' );
+
+/**
+ * Customize the pingbacks and trackbacks option on new posts by default.
+ *
+ * @param mixed  $value   The current option value.
+ * @param string $option The name of the option being filtered.
+ * @param mixed  $default The default value for the option.
+ *
+ * @return mixed The filtered option value. If the provided option is 'default_ping_status',
+ *               this function will set its value to 'closed' (disabling pingbacks and trackbacks),
+ *               and return the updated value. For other options, it returns the original value.
+ */
+function custom_disable_pingbacks_trackbacks_option( $value, $option, $default ) {
+    if ( 'default_ping_status' === $option ) {
+        $value = 'closed';
+    }
+
+    return $value;
+}
+
+add_filter( 'pre_option_default_ping_status', 'custom_disable_pingbacks_trackbacks_option', 10, 3 );
+
+/**
+ * Remove Trackbacks Support for the "post" Post Type.
+ */
+function remove_trackbacks_support() {
+	remove_post_type_support( 'post', 'trackbacks' );
+}
+
+add_action( 'init', 'remove_trackbacks_support' );

--- a/src/php/views/page.twig
+++ b/src/php/views/page.twig
@@ -1,7 +1,6 @@
 {% extends "layouts/base.twig" %}
 
 {% block content %}
-
 	<div class="obj-width-limiter">
 		<img
 			src="{{ post.thumbnail.src|resize(960) }}"
@@ -10,6 +9,8 @@
 			{% endif %}
 		/>
 		{{ post.content }}
+		{# Loads comments.php by default #}
+		{{ function('comments_template') }}
 	</div>
 
 {% endblock %}

--- a/src/php/views/partials/comments.twig
+++ b/src/php/views/partials/comments.twig
@@ -1,0 +1,18 @@
+{% if function('have_comments') %}
+  <div id="comments" class="{{ html_classes('post-comments', {
+    'show-avatars': should_show_avatars
+  }) }}">
+  <h2>Comments</h2>
+  <ul>
+    {{ function('wp_list_comments') }}
+  </ul>
+  {{ function('comment_form') }}
+  </div>
+  {% if not function('comments_open') %}
+    <p>Comments are closed</p>
+  {% endif %}
+{% else %}
+  {% if function('comments_open') %}
+    {{ function('comment_form') }}
+  {% endif %}
+{% endif %}


### PR DESCRIPTION
## Description

The original statement about comments/pingbacks/trackbacks in the issue stated that "The 'Discussion' section with comments/pingbacks shows up for pages and posts, but checking the boxes doesn't change any behavior". After some discussion, we determined that we could try to temporarily remove all menu options for comments, trackbacks, and pingbacks, and possibly address at least comments later. Removing comments altogether (particularly from the default post) proved difficult and didn't seem like a worthwhile pursuit since it was intended to be a temporary solution only, so this work:
- removes pingbacks and trackbacks to the extent possible
- supports the ability to have comments on posts if desired

<!-- If using GitHub issues, set the issue number to close it on merge -->
Closes #75

<!-- If using external project management, link to the issue/specification -->
<!-- [Issue](https://example.com/ISSUE_NUMBER) -->

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. View the "Hello world!" default post and confirm that the default comment (by "A WordPressCommenter" appears)
5. Check nested comments and ability to add comments:
    - You should be able to add a new comment
    - Adding a new comment should add another list item to the comments list with the comment
    - You should be able to reply to the existing comment, or reply to a new comment
    - You should be able to reply to a comment reply
    - Replying to a comment should nest that comment under the comment or comment reply to which you are applying
    - You should be able to add a comment when logged out, and see that this comment shows up for approval in the [Comments section](http://localhost:8000/wp-admin/edit-comments.php)
6. Other links in Comments section appear to function as expected.
7. Checking and unchecking "Show Avatars" in [Discussion Settings](http://localhost:8000/wp-admin/options-discussion.php) appears to have an effect on whether or not avatars appear in comments section (don't forget to Save Changes!)
8. Check that password-protected posts do not show comments unless you are viewing the post:
    - Add comments to an existing post, 
9. Toggling "Allow comments" on a post, or "Allow people to submit comments on new posts" from the [Discussion Settings](http://localhost:8000/wp-admin/options-discussion.php) (don't forget to Save Changes!) seems to have an effect on whether or not you should be able to add a comment.
10. Toggling "Allow comments" off on an existing post with comments shows existing comments along with a message that says that comments have been closed. Comment form does not appear.
11. Container does not abruptly stop in the process of doing any of this (this was happening to me, but I believe it was the result of making changes to `comments.php`)
