### PR TITLE
fix: exit deployment process early if nothing to commit

### DIFF
--- a/.github/workflows/deploy.pantheon.yml
+++ b/.github/workflows/deploy.pantheon.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Deploy to Pantheon
         run: |
           cd prod
-          git status
+          git status | grep "nothing to commit" && exit 0 || git status
           git add .
           git commit -m "Prod release"
           git push pantheon HEAD:master


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->
This adds a check to make sure there is something to commit before proceeding with the deployment to Pantheon. If there's nothing to commit, this will exit early with a success status so that changes that don't affect code that gets copied into the Pantheon repo don't get incorrectly considered as "failed" deployments.

<!-- If using GitHub issues, set the issue number to close it on merge -->
Closes #98

<!-- If using external project management, link to the issue/specification -->
<!-- [Issue](https://example.com/ISSUE_NUMBER) -->

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. View a [failed run](https://github.com/sparkbox/sparkpress-wordpress-starter/actions/runs/6589786740/job/17904992657) and confirm that it failed because there was nothing to commit
3. View the [successful run dispatched from this branch](https://github.com/sparkbox/sparkpress-wordpress-starter/actions/runs/6616215864/job/17970039828) and confirm that it succeeds despite there being nothing to commit to Pantheon's repo
<!-- Add additional validation steps here -->
