### PR TITLE
Support featured image

### DIFF
--- a/src/php/views/page.twig
+++ b/src/php/views/page.twig
@@ -3,6 +3,12 @@
 {% block content %}
 
 	<div class="obj-width-limiter">
+		<img
+			src="{{ post.thumbnail.src|resize(960) }}"
+			{% if post.thumbnail.alt and post.thumbnail.alt|length > 0 %}
+				alt="{{ post.thumbnail.alt }}"
+			{% endif %}
+		/>
 		{{ post.content }}
 	</div>
 

--- a/src/php/views/partials/content-single.twig
+++ b/src/php/views/partials/content-single.twig
@@ -1,8 +1,19 @@
-<article id="post-{{ post.id }}">
-	<h2>
-		{{ post.title }}
-	</h2>
+<article id="post-{{ post.id }}" class="post-preview">
+	{% if post.thumbnail %}
+		<img
+			src="{{ post.thumbnail.src('thumbnail') }}"
+			class="post-preview__featured-image"
+			{% if post.thumbnail.alt and post.thumbnail.alt|length > 0 %}
+				alt="{{ post.thumbnail.alt }}"
+			{% endif %}
+		/>
+	{% endif %}
 	<div>
-		{{ post.preview }}
+		<h2 class="post-preview__title">
+			{{ post.title }}
+		</h2>
+		<div>
+			{{ post.preview }}
+		</div>
 	</div>
 </article>

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -64,6 +64,7 @@
 //    and our UI components are often composed of Objects and Components
 @import 'components/main-nav';
 @import 'components/pagination';
+@import 'components/post-preview';
 @import 'components/primary-sidebar';
 @import 'components/post-body';
 @import 'components/skip-to-content';

--- a/src/scss/components/_post-preview.scss
+++ b/src/scss/components/_post-preview.scss
@@ -1,0 +1,20 @@
+.post-preview {
+  margin-bottom: 1.5rem;
+  min-height: 9.375rem; // 150px
+
+  @media (min-width: 50rem) {
+    display: flex;
+    column-gap: 1.5rem;
+  }
+
+  &__title {
+    margin: 0 0 1rem;
+  }
+
+  &__featured-image {
+    max-height: 9.375rem; // 150px
+    max-width: 9.375rem; // 150px
+    width: auto;
+    height: auto;
+  }
+}


### PR DESCRIPTION
## Description

Utilizes the featured image on a WordPress post in the post list (archive page) as a thumbnail and in the post.

<!-- If using GitHub issues, set the issue number to close it on merge -->
Addresses #75 

<!-- If using external project management, link to the issue/specification -->
<!-- [Issue](https://example.com/ISSUE_NUMBER) -->

## To Validate


<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. If you have posts with images, keep the database you already have, or add your own, or use the db backup attached below.
5. Navigate to localhost:8000 to check the archive page, check that thumbnails render and that styling seems appropriate.
6. Navigate to a post page that has a thumbnail image and check that image renders there and that styling seems appropriate.
7. Add a post with a featured image and confirm that image appears on archive page and on post page as expected.
8. Add alt text to a featured image if it does not have one already (you can do this in the Post by clicking on "Replace" to replace the image, then update the details and save). Confirm that the alt text is visible on the image for the archive page and for the post page.
<!-- Add additional validation steps here -->

[lorem-ipsum-with-img-2023-10-23T23-16-57_UTC.sql.gz](https://github.com/sparkbox/sparkpress-wordpress-starter/files/13090152/lorem-ipsum-with-img-2023-10-23T23-16-57_UTC.sql.gz)
