### PR TITLE
Fix: Widget formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,10 @@ By default, comments are turned off for pages, but can be enabled for pages indi
 1. Access the Page settings menu on the right side of the page
 1. Scroll down the menu to the option with the heading "Disucssion", check "Allow comments", and update the page
 
+### Widgets
+
+A footer widget area and a sidebar widget area (which appears below content on smaller screens) are built into the theme. Widgets can be added to these areas by navigating to Appearance > Widgets from the admin dashboard. Navigating to the widgets admin page will automatically fill the sidebar widget area with default content. Blocks can be added, edited, or removed here. If you wish to deactivate widgets but keep them available for later, widgets can be dragged and dropped into the Inactive widgets area. This is easiest done from the List View, which can be accessed via the button on the top left side of the page.
+
 ### Template Hierarchy
 
 This starter template covers the generic templates needed for things like single post pages, archive (or listing) pages, the 404 page, and the search page, but you can override those using [WordPress' template hierarchy](https://developer.wordpress.org/themes/basics/template-hierarchy/).

--- a/src/php/index.php
+++ b/src/php/index.php
@@ -24,6 +24,8 @@ $context['posts'] = new Timber\PostQuery();
 $templates        = array( 'index.twig' );
 if ( is_home() && ! is_front_page() ) {
 	$context['title'] = single_post_title();
+} elseif ( ! $context['posts']->found_posts ) {
+	$context['title'] = 'Nothing Found';
 } else {
 	$context['title'] = 'Recent Posts';
 }

--- a/src/php/views/404.twig
+++ b/src/php/views/404.twig
@@ -1,7 +1,9 @@
 {% extends "layouts/base.twig" %}
 
+{% block title %}
+	<h1>Nothing Found</h1>
+{% endblock %}
+
 {% block content %}
-	<div class="obj-width-limiter">
-		{% include 'partials/content-none.twig' %}
-	</div>
+	{% include 'partials/content-none.twig' %}
 {% endblock %}

--- a/src/php/views/index.twig
+++ b/src/php/views/index.twig
@@ -1,12 +1,15 @@
 {% extends "layouts/base.twig" %}
 
+{% block title %}
+	<h1>{{ title }}</h1>
+{% endblock %}
+
 {% block content %}
-	<div class="obj-width-limiter">
+	<div>
 		{% if posts.found_posts %}
 
 			{# new block that can be overwritten #}
 			{% block posts_found %}
-				<h1>{{ title }}</h1>
 				{% for post in posts %}
 					{% include 'partials/content-single.twig' with {post: post} %}
 				{% endfor %}

--- a/src/php/views/layouts/base.twig
+++ b/src/php/views/layouts/base.twig
@@ -14,21 +14,24 @@
 
 		<main id="main">
 			<article id="post-{{ post.id }}" class="post-type-{{ post.post_type }} {{ function('get_post_class')|join(' ') }}">
-				{% if post.title %}
-					<div class="obj-width-limiter">
-						<h1>{{ post.title }}</h1>
-					</div>
-				{% endif %}
 
-				<div class="cmp-post-body">
+				<div class="obj-width-limiter">
+					{% block title %}
+						{% if post.title %}
+							<h1>{{ post.title }}</h1>
+						{% endif %}
+					{% endblock %}
+				</div>
+
+				<div class="cmp-post-body obj-width-limiter">
 					{# content block from child templates #}
 					{% block content %}
-						<div class="obj-width-limiter">
+						<div>
 							Sorry, no content
 						</div>
 					{% endblock %}
 					{% if sidebar_widget %}
-						<aside class="obj-width-limiter cmp-primary-sidebar">
+						<aside class="cmp-primary-sidebar">
 							{{ sidebar_widget }}
 						</aside>
 					{% endif %}

--- a/src/php/views/page.twig
+++ b/src/php/views/page.twig
@@ -1,7 +1,7 @@
 {% extends "layouts/base.twig" %}
 
 {% block content %}
-	<div class="obj-width-limiter">
+	<div>
 		<img
 			src="{{ post.thumbnail.src|resize(960) }}"
 			{% if post.thumbnail.alt and post.thumbnail.alt|length > 0 %}

--- a/src/php/views/page.twig
+++ b/src/php/views/page.twig
@@ -2,12 +2,14 @@
 
 {% block content %}
 	<div>
-		<img
-			src="{{ post.thumbnail.src|resize(960) }}"
-			{% if post.thumbnail.alt and post.thumbnail.alt|length > 0 %}
-				alt="{{ post.thumbnail.alt }}"
-			{% endif %}
-		/>
+		{% if post.thumbnail %}
+			<img
+				src="{{ post.thumbnail.src|resize(960) }}"
+				{% if post.thumbnail.alt and post.thumbnail.alt|length > 0 %}
+					alt="{{ post.thumbnail.alt }}"
+				{% endif %}
+			/>
+		{% endif %}
 		{{ post.content }}
 		{# Loads comments.php by default #}
 		{{ function('comments_template') }}

--- a/src/php/views/partials/content-none.twig
+++ b/src/php/views/partials/content-none.twig
@@ -1,8 +1,4 @@
 <section>
-	<header>
-		<h1>Nothing Found</h1>
-	</header>
-
 	<div>
 		{{ function('get_search_form') }}
 	</div>

--- a/src/php/views/search.twig
+++ b/src/php/views/search.twig
@@ -1,7 +1,6 @@
 {% extends "index.twig" %}
 
 {% block posts_found %}
-  <h1>{{ title }}</h1>
   {% for post in posts %}
     {% include 'partials/content-search.twig' with {post: post} %}
   {% endfor %}

--- a/src/php/views/single-password.twig
+++ b/src/php/views/single-password.twig
@@ -1,7 +1,5 @@
 {% extends "layouts/base.twig" %}
 
 {% block content %}
-	<div class="obj-width-limiter">
-		{{ function('get_the_password_form') }}
-	</div>
+	{{ function('get_the_password_form') }}
 {% endblock %}

--- a/src/scss/components/_primary-sidebar.scss
+++ b/src/scss/components/_primary-sidebar.scss
@@ -3,6 +3,8 @@
   padding: 1rem;
   
   @media (min-width: 50rem) {
+    margin-inline-start: auto;
     flex-basis: 18.75rem;
+    flex-shrink: 0;
   }
 }


### PR DESCRIPTION
## Description

This PR makes some changes to the markup around the content block in order to resolve a bug that prevented the `.obj-width-limiter` class from centering/spacing content on the page appropriately when the sidebar widget is active. It also refactors how `h1` tags are added to the page, in order to push the sidebar below the `h1` for all pages.

Finally, this PR also adds a minor fix to prevent empty `img` tags from showing on the post page if there is no featured image added.

<!-- If using GitHub issues, set the issue number to close it on merge -->
Closes #119 
<!-- If using external project management, link to the issue/specification -->
<!-- [Issue](https://example.com/ISSUE_NUMBER) -->

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. _Without_ widgets activated [^1], view the following pages, they should appear the same as before (on `main`):
    * Index page, http://localhost:8000/
    * Post, for instance, http://localhost:8000/?p=1
    * Page, for instance, http://localhost:8000/?page_id=2
    * Search results, for instance, http://localhost:8000/?s=sample (this page does introduce about `1.5rem` of space after the `h1` because the `h1` is now in a container, unless someone has strong opinions about fixing it, I'm going to leave it to be fixed in the context of a project)
    * Archive page, for instance, http://localhost:8000/?m=202310
    * 404 page, for instance, http://localhost:8000/?p=234234
5. Now activate sidebar widget (go to Appearance > Widgets, navigating here should automatically fill the sidebar with widgets), and view the same pages listed above. Post and sidebar should both align with the `h1`, header, and footer on the left side. Sidebar should appear in the same place on every page.
6. Review the added documentation for accuracy, utility, and clarity.
<!-- Add additional validation steps here -->

[^1]: Fun fact: I learned today that you can deactivate the sidebar (or any) widgets but keep them around to bring them back easily by going to the list view in the widgets admin, and dragging the widgets in the sidebar area to the Inactive widgets area (shift-select or command-A to grab all widgets). I wrote about this in the documentation because it’s not obvious and prior to this I was wiping my database every time I wanted to take the widgets out, but it’s worth mentioning here for easier validation.
