### PR TITLE
chore: update WordPress to 6.3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM php:8.1-apache-buster as dev
 
 LABEL org.opencontainers.image.source=https://github.com/sparkbox/sparkpress-wordpress-starter
 
-# When changings, also change in .circleci/config.yml
-ENV WP_VERSION=6.3.1
+ENV WP_VERSION=6.3.2
 
 RUN apt-get update \
       && apt-get install -y libpng-dev libjpeg62-turbo-dev libzip-dev


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->
This updates WordPress to version 6.3.2. See the [release notes](https://wordpress.org/documentation/wordpress-version/version-6-3-2/) for details.

<!-- If using GitHub issues, set the issue number to close it on merge -->

<!-- If using external project management, link to the issue/specification -->
<!-- [Issue](https://example.com/ISSUE_NUMBER) -->

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Stop your development process if it's already running
4. Run `docker compose build`
5. Run `npm start`
6. Visit the WP dashboard and confirm that it shows as running WordPress version 6.3.2
7. Spot check pages for both the public-facing admin sides for any obvious issues
<!-- Add additional validation steps here -->
