### PR TITLE
fix: custom post type tags excluded from archive pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,8 @@ The following files will be created based on your inputs:
 - `src/php/views/single-<post-type-name>.twig` (optional)
 - `src/php/views/archive-<post-type-name>.twig` (optional)
 
+To allow for posts from your new custom post type to be shown on archive pages, you will also need to update `src/php/inc/setup-queries.php` to look for posts and your custom post types by default.
+
 [Custom Post Types documentation](https://wordpress.org/support/article/post-types/#custom-post-types)
 
 ### Custom Taxonomy

--- a/generators/page-template.js
+++ b/generators/page-template.js
@@ -18,7 +18,7 @@ render_with_password_protection( $timber_post, '${baseFileName}.twig', $context 
 const twigTemplate = `{% extends "layouts/base.twig" %}
 
 {% block content %}
-	<div class="obj-width-limiter">
+	<div>
 		{{ post.content }}
 	</div>
 {% endblock %}

--- a/generators/post-type.js
+++ b/generators/post-type.js
@@ -63,7 +63,7 @@ render_with_password_protection( $timber_post, $templates, $context );
 const getSinglePostTemplate = () => `{% extends "layouts/base.twig" %}
 
 {% block content %}
-  <div class="obj-width-limiter">
+  <div>
     {{ post.content }}
   </div>
 {% endblock %}
@@ -85,7 +85,7 @@ Timber\\Timber::render( $templates, $context );
 const getArchiveTemplate = () => `{% extends "layouts/base.twig" %}
 
 {% block content %}
-	<div class="obj-width-limiter">
+	<div>
 		{% if posts.found_posts %}
 			<h1>{{ title }}</h1>
 			{% for post in posts %}
@@ -186,6 +186,10 @@ const generatePostType = async () => {
 		writeFileSync(archiveTemplatePath, archiveTemplate, 'utf-8');
 		console.log(`Created ${archiveTemplatePath}`);
 	}
+
+	console.log(`
+Note: to get posts from your new custom post type to show up on archive pages, you will need to update enable_custom_posts_in_archives in ./src/php/inc/setup-queries.php.
+	`);
 };
 
 generatePostType();

--- a/generators/taxonomy.js
+++ b/generators/taxonomy.js
@@ -52,7 +52,7 @@ Timber\\Timber::render( $templates, $context );
 const getArchiveTemplate = () => `{% extends "layouts/base.twig" %}
 
 {% block content %}
-	<div class="obj-width-limiter">
+	<div>
 		{% if posts.found_posts %}
 			<h1>{{ title }}</h1>
 			{% for post in posts %}

--- a/src/php/inc/setup-queries.php
+++ b/src/php/inc/setup-queries.php
@@ -10,8 +10,35 @@
  * @return array
  */
 function sb_query_vars_filter( $vars ) {
-	$vars[] = 'example_var'; // e.g. allow ?example_var="test" in url.
+	// Allow custom query params in URL.
+	// e.g. $vars[] = 'example_var'; to allow ?example_var=test in URL.
 	return $vars;
 }
+// Uncomment this line if you've added custom query params.
+// add_filter( 'query_vars', 'sb_query_vars_filter' );
 
-add_filter( 'query_vars', 'sb_query_vars_filter' );
+/**
+ * Alter default query to fetch posts from custom post types on archive pages.
+ *
+ * @param object $query - The incoming query.
+ * @return object
+ */
+function enable_custom_posts_in_archives( $query ) {
+	if ( $query->is_admin() || $query->is_post_type_archive() ) {
+		return $query;
+	}
+
+	if ( $query->is_archive() || ( $query->is_home() && $query->is_main_query() ) ) {
+		$query->set(
+			'post_type',
+			array(
+				'post',
+				// Extend which post types will be queried by default on archive pages.
+				// e.g. 'recipe', to fetch posts for a custom post type with the slug 'recipe'
+			)
+		);
+	}
+
+	return $query;
+}
+add_filter( 'pre_get_posts', 'enable_custom_posts_in_archives' );

--- a/src/php/inc/theme-scripts.php
+++ b/src/php/inc/theme-scripts.php
@@ -9,9 +9,10 @@
  * Enqueue scripts and styles.
  */
 function sparkpress_theme_scripts() {
-	$example_data = array( '1', '2', '3' );
 	wp_enqueue_script( 'sparkpress-theme-script', get_template_directory_uri() . '/js/scripts.js', array(), _S_VERSION, true );
-	// Defines an `example` JavaScript variable, within the sparkpress-theme-script, equal to $example_data.
-	wp_localize_script( 'sparkpress-theme-script', 'example', $example_data );
+
+	// You can also define global variables that get appended to an enqueued script.
+	// e.g. wp_localize_script( 'sparkpress-theme-script', 'example', array( '1', '2', '3' ) );
+	// would define `example` as a global variable with a value of [1, 2, 3]
 }
 add_action( 'wp_footer', 'sparkpress_theme_scripts' );

--- a/src/php/inc/theme-setup.php
+++ b/src/php/inc/theme-setup.php
@@ -101,13 +101,12 @@ add_action( 'admin_init', 'custom_hide_editor' );
  *
  * @param mixed  $value   The current option value.
  * @param string $option The name of the option being filtered.
- * @param mixed  $default The default value for the option.
  *
  * @return mixed The filtered option value. If the provided option is 'default_ping_status',
  *               this function will set its value to 'closed' (disabling pingbacks and trackbacks),
  *               and return the updated value. For other options, it returns the original value.
  */
-function custom_disable_pingbacks_trackbacks_option( $value, $option, $default ) {
+function custom_disable_pingbacks_trackbacks_option( $value, $option ) {
     if ( 'default_ping_status' === $option ) {
         $value = 'closed';
     }


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->
This fixes an issue where posts from custom post types were excluded from archive pages, such as by date, category, or tag, as well as the home page which lists recent posts. It requires a little bit of manual intervention from developers when they generate post types, but it's a one-liner, and instructions were updated to make it clear what to do on post type creation.

<!-- If using GitHub issues, set the issue number to close it on merge -->
Closes #115 

<!-- If using external project management, link to the issue/specification -->
<!-- [Issue](https://example.com/ISSUE_NUMBER) -->

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Run `npm run generate:post-type` and answer the prompts to create a new custom post type, like "Recipes"
5. Confirm that the output of the generator includes a message about how to enable the post type on archive pages
6. Follow the instructions in the message/comments to add the post type to the `enable_custom_posts_in_archives` function
7. Add some categories and/or tags to regular posts
8. Create posts for the new post type and give some of them the same tags and categories as the other posts
9. Check the home page and confirm that your custom posts are listed along with regular posts
10. Check tag archives (`?tag=<tag-slug>`) to confirm all posts with that tag are rendered
11. Check category archives (`?cat=<category-id>`) to confirm all posts with that category are rendered
12. Check date archives (`?m=2023`) to confirm all posts authored in the given year are rendered
13. Check custom post type archives (`?post_type=<post-slug>`) and confirm that _only_ posts from the custom post type are rendered
<!-- Add additional validation steps here -->
