### PR TITLE
feat: add srcset for post image

### DIFF
--- a/src/php/views/page.twig
+++ b/src/php/views/page.twig
@@ -3,12 +3,21 @@
 {% block content %}
 	<div>
 		{% if post.thumbnail %}
-			<img
-				src="{{ post.thumbnail.src|resize(960) }}"
-				{% if post.thumbnail.alt and post.thumbnail.alt|length > 0 %}
-					alt="{{ post.thumbnail.alt }}"
-				{% endif %}
-			/>
+			{% set largest_image = post.thumbnail.src('large') %}
+			<picture>
+				{% for image_size in post.thumbnail.sizes|sort((a, b) => a.width <=> b.width)|keys %}
+					{% set largest_image = post.thumbnail.src(image_size) %}
+					<source srcset="{{ post.thumbnail.src(image_size) }}" media="(max-width: {{ post.thumbnail.sizes[image_size]['width'] }}px)" >
+				{% endfor %}
+				<img
+					src="{{ largest_image }}"
+					{% if post.thumbnail.alt and post.thumbnail.alt|length > 0 %}
+						alt="{{ post.thumbnail.alt }}"
+					{% else %}
+						alt=""
+					{% endif %}
+				>
+			</picture>
 		{% endif %}
 		{{ post.content }}
 		{# Loads comments.php by default #}

--- a/src/php/views/partials/content-single.twig
+++ b/src/php/views/partials/content-single.twig
@@ -5,6 +5,8 @@
 			class="post-preview__featured-image"
 			{% if post.thumbnail.alt and post.thumbnail.alt|length > 0 %}
 				alt="{{ post.thumbnail.alt }}"
+			{% else %}
+				alt=""
 			{% endif %}
 		/>
 	{% endif %}


### PR DESCRIPTION
## Description

Implements responsive images on posts using `srcset`. `src/php/views/partials/content-single.twig` still exclusively uses the thumbnail (150x150) image.

<!-- If using GitHub issues, set the issue number to close it on merge -->
Addresses #111 

<!-- If using external project management, link to the issue/specification -->
<!-- [Issue](https://example.com/ISSUE_NUMBER) -->

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Add a post with a featured image and navigate to it.
5. Open the Network tab in the inspector with a smaller screen width (around 300-400px), and reload the page. Note the name/size of the featured image that loads (it may be 300px wide/`medium` or 768px wide/`medium_large`), and slowly increase the size of the page, depending on your browser, you should see it load at least one other image size (1024px wide/`large`) before the browser window gets to 1000px wide. Different browsers seem to load different sized images and different widths as far as I could tell, but generally speaking smaller images are loaded for smaller screen widths.
<!-- Add additional validation steps here -->
