### PR TITLE
chore: use wordpress eslint plugin

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,13 @@
 		"sourceType": "module",
 		"ecmaVersion": "latest"
 	},
-	"extends": ["eslint:recommended", "plugin:react/recommended", "plugin:react-hooks/recommended", "prettier"],
+	"extends": [
+		"eslint:recommended",
+		"plugin:react/recommended",
+		"plugin:react-hooks/recommended",
+		"plugin:@wordpress/eslint-plugin/recommended-with-formatting",
+		"prettier"
+	],
 	"settings": {
 		"react": {
 			"version": "^18.2.0"

--- a/generators/custom-block.js
+++ b/generators/custom-block.js
@@ -26,7 +26,9 @@ const getBlockJsonTemplate = ({ pluginSlug, slugName, name, description, hasView
 }
 `;
 
-const getEditJSTemplate = ({ name }) => `/**
+const getEditJSTemplate = ({ name }) => `/** @typedef {import('@wordpress/element').WPElement} WPElement */
+
+/**
  * React hook that is used to mark the block wrapper element.
  * It provides all the necessary props like the class name.
  *
@@ -107,7 +109,9 @@ registerBlockType(metadata.name, {
 });
 `;
 
-const getSaveJSTemplate = ({ name }) => `/**
+const getSaveJSTemplate = ({ name }) => `/** @typedef {import('@wordpress/element').WPElement} WPElement */
+
+/**
  * React hook that is used to mark the block wrapper element.
  * It provides all the necessary props like the class name.
  *

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@testing-library/dom": "^9.3.3",
         "@testing-library/jest-dom": "^6.1.4",
         "@vitest/coverage-istanbul": "^0.34.6",
+        "@wordpress/eslint-plugin": "^17.1.0",
         "@wordpress/scripts": "^26.15.0",
         "autoprefixer": "^10.4.16",
         "check-node-version": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@testing-library/dom": "^9.3.3",
     "@testing-library/jest-dom": "^6.1.4",
     "@vitest/coverage-istanbul": "^0.34.6",
+    "@wordpress/eslint-plugin": "^17.1.0",
     "@wordpress/scripts": "^26.15.0",
     "autoprefixer": "^10.4.16",
     "check-node-version": "^4.2.1",


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->

<!-- If using GitHub issues, set the issue number to close it on merge -->
Closes #127 

<!-- If using external project management, link to the issue/specification -->
<!-- [Issue](https://example.com/ISSUE_NUMBER) -->

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm ci`
4. Run `npm run generate:custom-blocks-plugin`, then `npm run generate:custom-block` to create a test block that we can check our linting rules against
5. Run `npm run lint:js` and confirm that it runs successfully (it should report an error if your `view.js` has a `console.log` statement)
6. Delete type definitions or otherwise make changes to the generated JS files that should cause linting errors
7. Confirm that `npm run lint:js` reports the expected errors
<!-- Add additional validation steps here -->
