### PR TITLE
chore: use GITHUB_TOKEN in docker build

### DIFF
--- a/.github/workflows/deploy.docker.yml
+++ b/.github/workflows/deploy.docker.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{github.actor}}
-          password: ${{secrets.GH_TOKEN}}
+          password: ${{secrets.GITHUB_TOKEN}}
 
       - name: 'Build Inventory Image'
         run: |


### PR DESCRIPTION
## Description
Updates the docker workflow to use the auto-generated `GITHUB_TOKEN` instead of one that we set.
## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. View the successful [deployment workflow run](https://github.com/sparkbox/sparkpress-wordpress-starter/actions/runs/6710184272), dispatched from this branch
3. View the [latest Docker image](https://github.com/sparkbox/sparkpress-wordpress-starter/pkgs/container/sparkpress/142982627?tag=latest) that was pushed by the above workflow