### PR TITLE
chore: bump WordPress version to 6.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM php:8.1-apache-buster as dev
 
 LABEL org.opencontainers.image.source=https://github.com/sparkbox/sparkpress-wordpress-starter
 
-ENV WP_VERSION=6.3.2
+ENV WP_VERSION=6.4
 
 RUN apt-get update \
       && apt-get install -y libpng-dev libjpeg62-turbo-dev libzip-dev


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->
[WordPress 6.4 was recently released](https://wordpress.org/documentation/wordpress-version/version-6-4/). It doesn't appear to introduce any changes that would impact the starter template–it mostly adds new features, improvements, and a new default theme (that we don't use).

<!-- If using GitHub issues, set the issue number to close it on merge -->

<!-- If using external project management, link to the issue/specification -->
<!-- [Issue](https://example.com/ISSUE_NUMBER) -->

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Stop your development process (Ctrl+C, `docker compose down`)
4. Run `docker compose build`
5. Run `npm start`
6. Confirm that the site works as expected with no breaking changes or obvious issues
7. Check the site admin and confirm that the version is shown as 6.4 and that there aren't any obvious breaking changes or issues
<!-- Add additional validation steps here -->
